### PR TITLE
Added lowering to flatter ast

### DIFF
--- a/src/frontend/ast.rs
+++ b/src/frontend/ast.rs
@@ -383,7 +383,7 @@ pub enum Instruction {
     },
     Return {
         src: SourceRef,
-        value: Expr,
+        value: Option<Expr>,
     },
     Break(SourceRef),
     Continue(SourceRef),
@@ -506,7 +506,11 @@ impl Instruction {
                 }
             }
             Instruction::Return { src: _, value } => {
-                format!("return {}", value.as_str())
+                if let Some(value) = value {
+                    format!("return {};", value.as_str())
+                } else {
+                    "return;".to_string()
+                }
             }
             Instruction::InfiniteLoop { src: _, body } => {
                 format!("loop {}", body.as_str())

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -380,8 +380,6 @@ impl Parser {
             }
         }
 
-        // let paths_to_import = self.parse_path()?;
-
         // expect a semicolon
         let end = self.cur_token();
         if matches!(end, Token::Semicolon(_)) {

--- a/src/frontend/snapshots/proto__frontend__parser__parser@fn_def.pr.snap
+++ b/src/frontend/snapshots/proto__frontend__parser__parser@fn_def.pr.snap
@@ -4,9 +4,9 @@ expression: res
 input_file: src/frontend/parser_inputs/fn_def.pr
 ---
 module:
-  - "fn add (a i64, b i64) i64 { return a + b }"
+  - "fn add (a i64, b i64) i64 { return a + b; }"
   - "fn do_nothing () void {  }"
-  - fn do_nothing_ () void return 1
+  - fn do_nothing_ () void return 1;
 lexer_error: []
 parser_error: []
 

--- a/src/ir8/codeviewer.rs
+++ b/src/ir8/codeviewer.rs
@@ -88,6 +88,8 @@ impl VisitsLowIR<String, String, String> for CodeViewer {
             }
         }
         self.decrease_padding();
+        view.push('\n');
+        view.push_str(&self.pad_text("}".to_string()));
         Ok(view)
     }
 
@@ -106,10 +108,8 @@ impl VisitsLowIR<String, String, String> for CodeViewer {
                 view.push_str(&self.pad_text(format!(":{} ", name)));
                 if fields.pairs.len() > 0 {
                     view.push_str(&self.visit_pairs(&fields)?);
-                    view.push('\n');
-                    view.push_str(&self.pad_text("}".to_string()));
                 } else {
-                    view.push_str(" }");
+                    view.push_str("{ }");
                 }
                 Ok(view)
             }
@@ -209,12 +209,13 @@ impl VisitsLowIR<String, String, String> for CodeViewer {
                 } else {
                     view.push('\n');
                     self.increase_padding();
+                    let mut ins_strs = vec![];
                     for ins in instructions {
-                        view.push_str(&self.visit_ins(&ins)?);
-                        view.push('\n');
+                        ins_strs.push(self.visit_ins(&ins)?);
                     }
                     self.decrease_padding();
-                    view.push_str(&self.pad_text("}\n".to_string()));
+                    view.push_str(&ins_strs.join("\n\n"));
+                    view.push_str(&("\n".to_string() + &self.pad_text("}".to_string())));
                 }
                 Ok(view)
             }
@@ -271,9 +272,9 @@ impl VisitsLowIR<String, String, String> for CodeViewer {
                     self.block_type = CodeBlockType::InstructionPart;
                     let block = self.visit_ins(&block)?;
                     self.block_type = block_type;
-                    Ok(format!("@{} {}", directive, block))
+                    Ok(self.pad_text(format!("@{} {}", directive, block)))
                 } else {
-                    Ok(format!("@{}", directive))
+                    Ok(self.pad_text(format!("@{};", directive)))
                 }
             }
             LowIRIns::ConditionalBranchIns { pairs, src: _ } => {
@@ -285,10 +286,10 @@ impl VisitsLowIR<String, String, String> for CodeViewer {
                     if i == 0 {
                         let cond = self.visit_expr(&cond.clone().unwrap())?;
                         let ins = self.visit_ins(&ins)?;
-                        self.increase_padding();
+                        // self.increase_padding();
                         // for the first pair, we do if <cond> <ins>
                         view.push_str(&self.pad_text(format!("if {} {}", cond, ins)));
-                        self.decrease_padding();
+                        // self.decrease_padding();
                     } else if i < pairs.len() - 1 {
                         let cond = self.visit_expr(&cond.clone().unwrap())?;
                         let ins = self.visit_ins(&ins)?;

--- a/src/ir8/codeviewer.rs
+++ b/src/ir8/codeviewer.rs
@@ -1,0 +1,400 @@
+use super::lowir::{ExprPool, ExprRef, InsPool, InsRef, KeyValueBindings, LowIRExpr, LowIRIns};
+use super::visitir::{VisitIRError, VisitsLowIR};
+
+#[derive(Clone)]
+#[allow(dead_code)]
+enum CodeBlockType {
+    Regular,
+    InstructionPart,
+}
+
+#[allow(dead_code)]
+pub struct CodeViewer {
+    ins_pool: InsPool,
+    expr_pool: ExprPool,
+    left_padding: u16,
+    block_type: CodeBlockType,
+}
+
+#[allow(dead_code)]
+impl CodeViewer {
+    pub fn new(ins_pool: InsPool, expr_pool: ExprPool) -> Self {
+        Self {
+            left_padding: 0,
+            ins_pool,
+            expr_pool,
+            block_type: CodeBlockType::Regular,
+        }
+    }
+
+    pub fn unwrap(&mut self, res: Vec<Result<String, VisitIRError>>) -> Vec<String> {
+        let mut result = vec![];
+        for r in res {
+            match r {
+                Ok(s) => result.push(s.clone()),
+                Err(_) => {}
+            }
+        }
+        result
+    }
+
+    pub fn increase_padding(&mut self) {
+        self.left_padding += 4;
+    }
+
+    pub fn decrease_padding(&mut self) {
+        self.left_padding -= 4;
+    }
+
+    pub fn pad_text(&self, text: String) -> String {
+        let padding = " ".repeat(self.left_padding as usize);
+        format!("{}{}", padding, text)
+    }
+
+    pub fn get_ins_pool(self) -> InsPool {
+        self.ins_pool
+    }
+
+    pub fn get_expr_pool(self) -> ExprPool {
+        self.expr_pool
+    }
+}
+
+impl VisitsLowIR<String, String, String> for CodeViewer {
+    fn visit_pairs(&mut self, kv: &KeyValueBindings) -> Result<String, VisitIRError> {
+        let mut view = String::from("{");
+        let kv_pair_len = kv.pairs.len();
+        if kv_pair_len > 0 {
+            self.increase_padding();
+        } else {
+            view.push_str(" }");
+            return Ok(view);
+        }
+
+        let mut count = 0;
+        for (key, value) in &kv.pairs {
+            let key = self.visit_expr(&key)?;
+            if let Some(value) = value {
+                let value = self.visit_expr(&value)?;
+                view.push('\n');
+                view.push_str(&self.pad_text(format!("{} = {}", key, value)));
+            } else {
+                view.push('\n');
+                view.push_str(&self.pad_text(format!("{}", key)));
+            }
+            count += 1;
+            if count < kv_pair_len {
+                view.push(',');
+            }
+        }
+        self.decrease_padding();
+        Ok(view)
+    }
+
+    fn visit_ins(&mut self, ins: &InsRef) -> Result<String, VisitIRError> {
+        // get instruction from pool
+        let ins_node = self.ins_pool.get(&ins);
+
+        match ins_node {
+            LowIRIns::NamedStructDecl {
+                name,
+                fields,
+                src: _,
+            } => {
+                let name = self.visit_expr(&name)?;
+                let mut view = String::new();
+                view.push_str(&self.pad_text(format!(":{} ", name)));
+                if fields.pairs.len() > 0 {
+                    view.push_str(&self.visit_pairs(&fields)?);
+                    view.push('\n');
+                    view.push_str(&self.pad_text("}".to_string()));
+                } else {
+                    view.push_str(" }");
+                }
+                Ok(view)
+            }
+            LowIRIns::ConstantDecl {
+                const_name,
+                const_type: _,
+                init_expr,
+                src_ref: _,
+                is_public,
+            } => {
+                let const_name = const_name.as_str();
+                let init_expr = self.visit_expr(&init_expr)?;
+                let mut view = format!("let {} = {}", const_name, init_expr);
+                if is_public {
+                    view = format!("pub {}", view);
+                }
+                Ok(self.pad_text(view))
+            }
+            LowIRIns::VariableDecl(var_name, _, init_expr, _) => {
+                let var_name = var_name.as_str();
+                if let Some(init_expr) = init_expr {
+                    let init_expr = self.visit_expr(&init_expr)?;
+                    Ok(self.pad_text(format!("mut {} = {}", var_name, init_expr)))
+                } else {
+                    Ok(self.pad_text(format!("mut {}", var_name)))
+                }
+            }
+            LowIRIns::AssignmentIns(target, val) => {
+                let target = self.visit_expr(&target)?;
+                let val = self.visit_expr(&val)?;
+                Ok(self.pad_text(format!("{} = {};", target, val)))
+            }
+            LowIRIns::ExpressionIns(expr, _) => {
+                let expr = self.visit_expr(&expr)?;
+                Ok(self.pad_text(format!("{};", expr)))
+            }
+            LowIRIns::FunctionDef {
+                name,
+                params,
+                return_type,
+                body,
+                is_public,
+                src: _,
+            } => {
+                let name = name.as_str();
+                let mut param_strs = vec![];
+                for param in params {
+                    param_strs.push(self.visit_expr(&param)?);
+                }
+                let params = param_strs.join(", ");
+                let return_type = return_type.as_str();
+                let block_type = self.block_type.clone();
+                self.block_type = CodeBlockType::InstructionPart;
+                let body = self.visit_ins(&body)?;
+                self.block_type = block_type;
+                let mut view = format!("fn {name}({params}) {return_type} {body}");
+                if is_public {
+                    view = format!("pub {}", view);
+                }
+                Ok(self.pad_text(view))
+            }
+            LowIRIns::InfiniteLoop { src: _, body } => {
+                let block_type = self.block_type.clone();
+                self.block_type = CodeBlockType::InstructionPart;
+                let body = self.visit_ins(&body)?;
+                self.block_type = block_type;
+                Ok(self.pad_text(format!("loop {}", body)))
+            }
+            LowIRIns::WhileLoop {
+                src: _,
+                condition,
+                body,
+            } => {
+                let condition = self.visit_expr(&condition)?;
+                let block_type = self.block_type.clone();
+                self.block_type = CodeBlockType::InstructionPart;
+                let body = self.visit_ins(&body)?;
+                self.block_type = block_type;
+                Ok(self.pad_text(format!("while {} {}", condition, body)))
+            }
+            LowIRIns::CodeBlock {
+                src: _,
+                instructions,
+            } => {
+                let mut view = String::new();
+                match self.block_type {
+                    CodeBlockType::InstructionPart => {
+                        view.push_str("{");
+                    }
+                    CodeBlockType::Regular => {
+                        view.push_str(&self.pad_text("{\n".to_string()));
+                    }
+                }
+
+                if instructions.len() == 0 {
+                    view.push_str(" }");
+                } else {
+                    view.push('\n');
+                    self.increase_padding();
+                    for ins in instructions {
+                        view.push_str(&self.visit_ins(&ins)?);
+                        view.push('\n');
+                    }
+                    self.decrease_padding();
+                    view.push_str(&self.pad_text("}\n".to_string()));
+                }
+                Ok(view)
+            }
+            LowIRIns::Module {
+                name,
+                body,
+                src: _,
+                is_public,
+            } => {
+                let name = self.visit_expr(&name)?;
+                let block_type = self.block_type.clone();
+                self.block_type = CodeBlockType::InstructionPart;
+                let body = self.visit_ins(&body)?;
+                self.block_type = block_type;
+                let mut view = format!("mod {} {}", name, body);
+                if is_public {
+                    view = format!("pub {}", view);
+                }
+                Ok(self.pad_text(view))
+            }
+            LowIRIns::Return { src: _, value } => {
+                if let Some(value) = value {
+                    let value = self.visit_expr(&value)?;
+                    Ok(self.pad_text(format!("return {};", value)))
+                } else {
+                    Ok(self.pad_text("return;".to_string()))
+                }
+            }
+            LowIRIns::Break(_) => Ok(self.pad_text("break;".to_string())),
+            LowIRIns::Continue(_) => Ok(self.pad_text("continue;".to_string())),
+            LowIRIns::UseDependency { paths, src: _ } => {
+                let mut path_str = String::new();
+                for (i, path) in paths.iter().enumerate() {
+                    for (j, part) in path.actions.iter().enumerate() {
+                        path_str.push_str(&part.as_str());
+                        if j + 1 < path.actions.len() {
+                            path_str.push_str("::");
+                        }
+                    }
+                    if i + 1 < paths.len() {
+                        path_str.push_str(", ");
+                    }
+                }
+                Ok(format!("use {};", path_str))
+            }
+            LowIRIns::DirectiveInstruction {
+                directive,
+                block,
+                src: _,
+            } => {
+                let directive = self.visit_expr(&directive)?;
+                if let Some(block) = block {
+                    let block_type = self.block_type.clone();
+                    self.block_type = CodeBlockType::InstructionPart;
+                    let block = self.visit_ins(&block)?;
+                    self.block_type = block_type;
+                    Ok(format!("@{} {}", directive, block))
+                } else {
+                    Ok(format!("@{}", directive))
+                }
+            }
+            LowIRIns::ConditionalBranchIns { pairs, src: _ } => {
+                let mut view = String::new();
+                let block_type = self.block_type.clone();
+                self.block_type = CodeBlockType::InstructionPart;
+                for i in 0..pairs.len() {
+                    let (cond, ins) = &pairs[i];
+                    if i == 0 {
+                        let cond = self.visit_expr(&cond.clone().unwrap())?;
+                        let ins = self.visit_ins(&ins)?;
+                        self.increase_padding();
+                        // for the first pair, we do if <cond> <ins>
+                        view.push_str(&self.pad_text(format!("if {} {}", cond, ins)));
+                        self.decrease_padding();
+                    } else if i < pairs.len() - 1 {
+                        let cond = self.visit_expr(&cond.clone().unwrap())?;
+                        let ins = self.visit_ins(&ins)?;
+                        self.increase_padding();
+                        // for the rest, we do else if <cond> <ins>
+                        view.push_str(&format!(" else if {} {}", cond, ins));
+                        self.decrease_padding();
+                    } else {
+                        // for the last, we do else <ins>
+                        let ins = self.visit_ins(&ins)?;
+                        self.increase_padding();
+                        view.push_str(&format!(" else {}", ins));
+                        self.decrease_padding();
+                    }
+                }
+                self.block_type = block_type;
+                Ok(view)
+            }
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &ExprRef) -> Result<String, VisitIRError> {
+        // get expr from pool
+        let expr_node = self.expr_pool.get(&expr);
+
+        match expr_node {
+            LowIRExpr::Id(token, id_type) => {
+                if let Some(id_type) = id_type {
+                    Ok(format!("{} {}", token.as_str(), id_type.as_str()))
+                } else {
+                    Ok(token.as_str())
+                }
+            }
+            LowIRExpr::Number(num, _) => Ok(num.as_str()),
+            LowIRExpr::StringLiteral(lit, _) => Ok(lit.as_str()),
+            LowIRExpr::CharacterLiteral(lit, _) => Ok(lit.as_str()),
+            LowIRExpr::Binary(operator, lhs, rhs, _) => {
+                let lhs = self.visit_expr(&lhs)?;
+                let rhs = self.visit_expr(&rhs)?;
+                Ok(format!("{} {} {}", lhs, operator.as_str(), rhs))
+            }
+            LowIRExpr::Comparison(operator, lhs, rhs, _) => {
+                let lhs = self.visit_expr(&lhs)?;
+                let rhs = self.visit_expr(&rhs)?;
+                Ok(format!("{} {} {}", lhs, operator.as_str(), rhs))
+            }
+            LowIRExpr::Boolean(lit, _) => Ok(lit.as_str()),
+            LowIRExpr::Unary(operator, expr, _) => {
+                let expr = self.visit_expr(&expr)?;
+                Ok(format!("{}{}", operator.as_str(), expr))
+            }
+            LowIRExpr::Grouped(inner_expr, _, _) => {
+                let inner_expr = self.visit_expr(&inner_expr)?;
+                Ok(format!("({})", inner_expr))
+            }
+            LowIRExpr::FnCall {
+                func,
+                args,
+                span: _,
+                fn_type: _,
+            } => {
+                let func = self.visit_expr(&func)?;
+                let args_str = args
+                    .iter()
+                    .map(|arg| self.visit_expr(&arg))
+                    .collect::<Result<Vec<String>, VisitIRError>>()?;
+                let args_str = args_str.join(", ");
+                Ok(format!("{}({})", func, args_str))
+            }
+            LowIRExpr::ScopeInto {
+                module,
+                target,
+                src: _,
+                resolved_type: _,
+            } => {
+                let module = self.visit_expr(&module)?;
+                let target = self.visit_expr(&target)?;
+                Ok(format!("{}::{}", module, target))
+            }
+            LowIRExpr::DirectiveExpr {
+                directive,
+                expr,
+                resolved_type: _,
+                src: _,
+            } => {
+                let directive = self.visit_expr(&directive)?;
+                if let Some(expr) = expr {
+                    let expr = self.visit_expr(&expr)?;
+                    Ok(format!("@{} {}", directive, expr))
+                } else {
+                    Ok(format!("@{}", directive))
+                }
+            }
+            LowIRExpr::NamedStructInit {
+                name,
+                fields,
+                src: _,
+                resolved_type: _,
+            } => {
+                let name = self.visit_expr(&name)?;
+                let block_type = self.block_type.clone();
+                self.block_type = CodeBlockType::InstructionPart;
+                let fields = self.visit_pairs(&fields)?;
+                self.block_type = block_type;
+                Ok(format!(":{} {}", name, fields))
+            }
+        }
+    }
+}

--- a/src/ir8/codeviewer.rs
+++ b/src/ir8/codeviewer.rs
@@ -39,11 +39,11 @@ impl CodeViewer {
     }
 
     pub fn increase_padding(&mut self) {
-        self.left_padding += 4;
+        self.left_padding += 2;
     }
 
     pub fn decrease_padding(&mut self) {
-        self.left_padding -= 4;
+        self.left_padding -= 2;
     }
 
     pub fn pad_text(&self, text: String) -> String {

--- a/src/ir8/lowir.rs
+++ b/src/ir8/lowir.rs
@@ -1,0 +1,734 @@
+use crate::frontend::{
+    ast::{
+        CompilationModule, DependencyPath, Expr, Instruction, KeyValueBindings as TreeKVBindings,
+    },
+    source::SourceRef,
+    token::Token,
+    types::Type,
+};
+
+// use super::visitir::{VisitIRError, VisitsLowIR};
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct KeyValueBindings {
+    pub pairs: Vec<(ExprRef, Option<ExprRef>)>,
+    pub span: SourceRef,
+}
+
+#[allow(dead_code)]
+impl KeyValueBindings {
+    pub fn as_str(&self) -> String {
+        let mut s = String::from("{ ");
+        for (index, (k, v)) in self.pairs.iter().enumerate() {
+            s.push_str(&k.as_str());
+            if let Some(v) = v {
+                s.push_str(" = ");
+                s.push_str(&v.as_str());
+            }
+
+            if index < self.pairs.len() - 1 {
+                s.push_str(", ");
+            }
+        }
+        s.push_str(" }");
+        s
+    }
+
+    pub fn source_ref(&self) -> SourceRef {
+        self.span.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum LowIRExpr {
+    Id(Token, Option<Type>),
+    Number(Token, Option<Type>),
+    StringLiteral(Token, Option<Type>),
+    CharacterLiteral(Token, Option<Type>),
+    Binary(Token, ExprRef, ExprRef, Option<Type>),
+    Comparison(Token, ExprRef, ExprRef, Option<Type>),
+    Boolean(Token, Option<Type>),
+    Unary(Token, ExprRef, Option<Type>),
+    Grouped(ExprRef, Option<Type>, SourceRef),
+    FnCall {
+        func: ExprRef,
+        args: Vec<ExprRef>,
+        span: SourceRef,
+        fn_type: Option<Type>,
+    },
+    ScopeInto {
+        module: ExprRef,
+        target: ExprRef,
+        src: SourceRef,
+        resolved_type: Option<Type>,
+    },
+    DirectiveExpr {
+        directive: ExprRef,
+        expr: Option<ExprRef>,
+        resolved_type: Option<Type>,
+        src: SourceRef,
+    },
+    NamedStructInit {
+        name: ExprRef,
+        fields: KeyValueBindings,
+        src: SourceRef,
+        resolved_type: Option<Type>,
+    },
+}
+
+#[allow(dead_code)]
+impl LowIRExpr {
+    pub fn type_info(&self) -> Option<Type> {
+        match &self {
+            LowIRExpr::Id(_, t) => t.clone(),
+            LowIRExpr::Number(_, t) => t.clone(),
+            LowIRExpr::Binary(_, _, _, t) => t.clone(),
+            LowIRExpr::Boolean(_, t) => t.clone(),
+            LowIRExpr::Unary(_, _, t) => t.clone(),
+            LowIRExpr::Comparison(_, _, _, t) => t.clone(),
+            LowIRExpr::FnCall {
+                func: _,
+                args: _,
+                span: _,
+                fn_type,
+            } => fn_type.clone(),
+            LowIRExpr::Grouped(_, t, _) => t.clone(),
+            LowIRExpr::ScopeInto {
+                module: _,
+                target: _,
+                src: _,
+                resolved_type,
+            } => resolved_type.clone(),
+            LowIRExpr::DirectiveExpr {
+                directive: _,
+                expr: _,
+                resolved_type,
+                src: _,
+            } => resolved_type.clone(),
+            LowIRExpr::StringLiteral(_, t) => t.clone(),
+            LowIRExpr::CharacterLiteral(_, t) => t.clone(),
+            LowIRExpr::NamedStructInit {
+                name: _,
+                fields: _,
+                src: _,
+                resolved_type,
+            } => resolved_type.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ExprRef {
+    pub loc: usize,
+}
+
+impl ExprRef {
+    pub fn as_str(&self) -> String {
+        format!("ExprRef({})", self.loc)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExprPool {
+    pub pool: Vec<LowIRExpr>,
+}
+
+#[allow(dead_code)]
+impl ExprPool {
+    pub fn new() -> Self {
+        ExprPool { pool: Vec::new() }
+    }
+
+    fn add(&mut self, expr: LowIRExpr) -> ExprRef {
+        self.pool.push(expr);
+        ExprRef {
+            loc: self.pool.len() - 1,
+        }
+    }
+
+    pub fn lowir(&mut self, expr: Expr) -> ExprRef {
+        match expr {
+            Expr::Id(id, t) => self.add(LowIRExpr::Id(id, t)),
+            Expr::Number(n, t) => self.add(LowIRExpr::Number(n, t)),
+            Expr::StringLiteral(s, t) => self.add(LowIRExpr::StringLiteral(s, t)),
+            Expr::CharacterLiteral(c, t) => self.add(LowIRExpr::CharacterLiteral(c, t)),
+            Expr::Binary(op, lhs, rhs, t) => {
+                let lhs = self.lowir(*lhs);
+                let rhs = self.lowir(*rhs);
+                self.add(LowIRExpr::Binary(op, lhs, rhs, t))
+            }
+            Expr::Comparison(op, lhs, rhs, t) => {
+                let lhs = self.lowir(*lhs);
+                let rhs = self.lowir(*rhs);
+                self.add(LowIRExpr::Comparison(op, lhs, rhs, t))
+            }
+            Expr::Boolean(b, t) => self.add(LowIRExpr::Boolean(b, t)),
+            Expr::Unary(op, expr, t) => {
+                let expr = self.lowir(*expr);
+                self.add(LowIRExpr::Unary(op, expr, t))
+            }
+            Expr::Grouped(expr, t, src) => {
+                let expr = self.lowir(*expr);
+                self.add(LowIRExpr::Grouped(expr, t, src))
+            }
+            Expr::FnCall {
+                func,
+                args,
+                span,
+                fn_type,
+            } => {
+                let func = self.lowir(*func);
+                let args = args
+                    .into_iter()
+                    .map(|arg| self.lowir(arg))
+                    .collect::<Vec<ExprRef>>();
+                self.add(LowIRExpr::FnCall {
+                    func,
+                    args,
+                    span,
+                    fn_type,
+                })
+            }
+            Expr::ScopeInto {
+                module,
+                target,
+                src,
+                resolved_type,
+            } => {
+                let module = self.lowir(*module);
+                let target = self.lowir(*target);
+                self.add(LowIRExpr::ScopeInto {
+                    module,
+                    target,
+                    src,
+                    resolved_type,
+                })
+            }
+            Expr::DirectiveExpr {
+                directive,
+                expr,
+                resolved_type,
+                src,
+            } => {
+                let directive = self.lowir(*directive);
+                let expr = expr.map(|expr| self.lowir(*expr));
+                self.add(LowIRExpr::DirectiveExpr {
+                    directive,
+                    expr,
+                    resolved_type,
+                    src,
+                })
+            }
+            Expr::NamedStructInit {
+                name,
+                fields,
+                src,
+                resolved_type,
+            } => {
+                let name = self.lowir(*name);
+                let fields = self.lowir_bindings(fields);
+                self.add(LowIRExpr::NamedStructInit {
+                    name,
+                    fields,
+                    src,
+                    resolved_type,
+                })
+            }
+        }
+    }
+
+    fn lowir_bindings(&mut self, bindings: TreeKVBindings) -> KeyValueBindings {
+        let nbindings = bindings
+            .pairs
+            .iter()
+            .map(|pair| {
+                let key = self.lowir(pair.0.clone());
+                if let Some(value) = pair.1.clone() {
+                    let value = self.lowir(value);
+                    (key, Some(value))
+                } else {
+                    (key, None)
+                }
+            })
+            .collect::<Vec<(ExprRef, Option<ExprRef>)>>();
+        KeyValueBindings {
+            pairs: nbindings,
+            span: bindings.span,
+        }
+    }
+
+    pub fn get(&self, expr_ref: &ExprRef) -> LowIRExpr {
+        self.pool[expr_ref.loc].clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum LowIRIns {
+    NamedStructDecl {
+        name: ExprRef,
+        fields: KeyValueBindings,
+        src: SourceRef,
+    },
+    ConstantDecl {
+        const_name: Token,
+        const_type: Option<Type>,
+        init_expr: ExprRef,
+        src_ref: SourceRef,
+        is_public: bool,
+    },
+    VariableDecl(Token, Option<Type>, Option<ExprRef>, SourceRef),
+    AssignmentIns(ExprRef, ExprRef),
+    ExpressionIns(ExprRef, Token),
+    FunctionDef {
+        name: Token,
+        params: Vec<ExprRef>,
+        return_type: Type,
+        body: InsRef,
+        is_public: bool,
+        src: SourceRef,
+    },
+    InfiniteLoop {
+        src: SourceRef,
+        body: InsRef,
+    },
+    WhileLoop {
+        src: SourceRef,
+        condition: ExprRef,
+        body: InsRef,
+    },
+    CodeBlock {
+        src: SourceRef,
+        instructions: Vec<InsRef>,
+    },
+    Module {
+        name: ExprRef,
+        body: InsRef,
+        src: SourceRef,
+        is_public: bool,
+    },
+    Return {
+        src: SourceRef,
+        value: Option<ExprRef>,
+    },
+    Break(SourceRef),
+    Continue(SourceRef),
+    UseDependency {
+        paths: Vec<DependencyPath>,
+        src: SourceRef,
+    },
+    DirectiveInstruction {
+        directive: ExprRef,
+        block: Option<InsRef>,
+        src: SourceRef,
+    },
+    ConditionalBranchIns {
+        pairs: Vec<(Option<ExprRef>, InsRef)>,
+        src: SourceRef,
+    },
+}
+
+impl LowIRIns {
+    pub fn as_str(&self) -> String {
+        match self {
+            LowIRIns::NamedStructDecl {
+                name,
+                fields,
+                src: _,
+            } => {
+                format!(":{} {}", name.as_str(), fields.as_str())
+            }
+            LowIRIns::ConstantDecl {
+                const_name,
+                const_type: t,
+                init_expr,
+                src_ref: _,
+                is_public: _,
+            } => match t {
+                Some(c_type) => {
+                    format!(
+                        "let {} {} = {};",
+                        const_name.as_str(),
+                        c_type.as_str(),
+                        init_expr.as_str()
+                    )
+                }
+                None => {
+                    format!("let {} = {};", const_name.as_str(), init_expr.as_str())
+                }
+            },
+            LowIRIns::VariableDecl(name, t, init, _) => match (t, init) {
+                (None, None) => format!("mut {};", name.as_str()),
+                (None, Some(init)) => format!("mut {} = {};", name.as_str(), init.as_str()),
+                (Some(c_type), None) => {
+                    format!("mut {} {};", name.as_str(), c_type.as_str())
+                }
+                (Some(c_type), Some(init)) => format!(
+                    "mut {} {} = {};",
+                    name.as_str(),
+                    c_type.as_str(),
+                    init.as_str()
+                ),
+            },
+            LowIRIns::AssignmentIns(target, value) => {
+                format!("{} = {};", target.as_str(), value.as_str())
+            }
+            LowIRIns::ExpressionIns(expr, _) => format!("{};", expr.as_str()),
+            LowIRIns::FunctionDef {
+                name,
+                params,
+                return_type,
+                body,
+                is_public,
+                src: _,
+            } => {
+                // collect param strings
+                let mut param_strs = String::new();
+                for (i, param) in params.iter().enumerate() {
+                    param_strs.push_str(&param.as_str());
+                    if i + 1 < params.len() {
+                        param_strs.push_str(", ");
+                    }
+                }
+                let str_rep = format!(
+                    "fn {} ({param_strs}) {} {}",
+                    name.as_str(),
+                    return_type.as_str(),
+                    body.as_str()
+                );
+                if *is_public {
+                    "pub ".to_string() + &str_rep
+                } else {
+                    str_rep
+                }
+            }
+            LowIRIns::CodeBlock {
+                src: _,
+                instructions,
+            } => {
+                let mut ins_str = "{ ".to_string();
+
+                for (id, ins) in instructions.iter().enumerate() {
+                    ins_str.push_str(&ins.as_str());
+
+                    if id + 1 < instructions.len() {
+                        ins_str.push(' ');
+                    }
+                }
+                ins_str + " }"
+            }
+            LowIRIns::Module {
+                name,
+                body,
+                src: _,
+                is_public,
+            } => {
+                let mod_str = format!("mod {} {}", name.as_str(), body.as_str());
+                if *is_public {
+                    mod_str
+                } else {
+                    "pub ".to_string() + &mod_str
+                }
+            }
+            LowIRIns::Return { src: _, value } => match value {
+                Some(v) => format!("return {};", v.as_str()),
+                None => "return;".to_string(),
+            },
+            LowIRIns::InfiniteLoop { src: _, body } => {
+                format!("loop {}", body.as_str())
+            }
+            LowIRIns::WhileLoop {
+                src: _,
+                condition,
+                body,
+            } => {
+                format!("while {} {}", condition.as_str(), body.as_str())
+            }
+            LowIRIns::Break(_) => "break;".to_string(),
+            LowIRIns::Continue(_) => "continue;".to_string(),
+            LowIRIns::UseDependency { paths, src: _ } => {
+                let mut path_str = String::new();
+                for (i, path) in paths.iter().enumerate() {
+                    for (j, part) in path.actions.iter().enumerate() {
+                        path_str.push_str(&part.as_str());
+                        if j + 1 < path.actions.len() {
+                            path_str.push_str("::");
+                        }
+                    }
+                    if i + 1 < paths.len() {
+                        path_str.push_str(", ");
+                    }
+                }
+                format!("use {};", path_str)
+            }
+            LowIRIns::DirectiveInstruction {
+                directive,
+                block,
+                src: _,
+            } => {
+                if let Some(block) = block {
+                    format!("@{} {}", directive.as_str(), block.as_str())
+                } else {
+                    format!("@{}", directive.as_str())
+                }
+            }
+            LowIRIns::ConditionalBranchIns { pairs, src: _ } => {
+                let mut str_rep = String::new();
+                for i in 0..pairs.len() {
+                    let (cond, ins) = &pairs[i];
+                    if i == 0 {
+                        // for the first pair, we do if <cond> <ins>
+                        str_rep.push_str(&format!(
+                            "if {} {}",
+                            cond.clone().unwrap().as_str(),
+                            ins.as_str()
+                        ));
+                    } else if i < pairs.len() - 1 {
+                        // for the rest, we do else if <cond> <ins>
+                        str_rep.push_str(&format!(
+                            " else if {} {}",
+                            cond.clone().unwrap().as_str(),
+                            ins.as_str()
+                        ));
+                    } else {
+                        // for the last, we do else <ins>
+                        str_rep.push_str(&format!(" else {}", ins.as_str()));
+                    }
+                }
+                str_rep
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct InsRef {
+    pub loc: usize,
+}
+
+impl InsRef {
+    pub fn as_str(&self) -> String {
+        format!("InsRef({})", self.loc)
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct InsPool {
+    pub pool: Vec<LowIRIns>,
+}
+
+#[allow(dead_code)]
+impl InsPool {
+    pub fn new() -> InsPool {
+        InsPool { pool: Vec::new() }
+    }
+
+    fn exists(&self, ins: &LowIRIns) -> Option<InsRef> {
+        for (i, ins2) in self.pool.iter().enumerate() {
+            if ins.as_str() == ins2.as_str() {
+                return Some(InsRef { loc: i });
+            }
+        }
+        None
+    }
+
+    fn add(&mut self, ins: LowIRIns) -> InsRef {
+        self.pool.push(ins);
+        InsRef {
+            loc: self.pool.len() - 1,
+        }
+    }
+
+    pub fn lowir(&mut self, epool: &mut ExprPool, ins: Instruction) -> InsRef {
+        match ins {
+            Instruction::NamedStructDecl { name, fields, src } => {
+                let name_ref = epool.lowir(name);
+                let fields = epool.lowir_bindings(fields);
+                let ins = LowIRIns::NamedStructDecl {
+                    name: name_ref,
+                    fields,
+                    src,
+                };
+                self.add(ins)
+            }
+            Instruction::ConstantDecl {
+                const_name,
+                const_type,
+                init_expr,
+                src_ref,
+                is_public,
+            } => {
+                let init_expr = epool.lowir(init_expr);
+                let ins = LowIRIns::ConstantDecl {
+                    const_name,
+                    const_type,
+                    init_expr,
+                    src_ref,
+                    is_public,
+                };
+                self.add(ins)
+            }
+            Instruction::VariableDecl(name, var_type, init_expr, span) => {
+                let init_expr = init_expr.map(|e| epool.lowir(e));
+                let ins = LowIRIns::VariableDecl(name, var_type, init_expr, span);
+                self.add(ins)
+            }
+            Instruction::AssignmentIns(dest, target) => {
+                let dest = epool.lowir(dest);
+                let target = epool.lowir(target);
+                let ins = LowIRIns::AssignmentIns(dest, target);
+                self.add(ins)
+            }
+            Instruction::ExpressionIns(expr, semi) => {
+                let expr = epool.lowir(expr);
+                let ins = LowIRIns::ExpressionIns(expr, semi);
+                self.add(ins)
+            }
+            Instruction::FunctionDef {
+                name,
+                params,
+                return_type,
+                body,
+                is_public,
+                src,
+            } => {
+                let params = params.into_iter().map(|p| epool.lowir(p)).collect();
+                let body = self.lowir(epool, *body);
+                let ins = LowIRIns::FunctionDef {
+                    name,
+                    params,
+                    return_type,
+                    body,
+                    is_public,
+                    src,
+                };
+                self.add(ins)
+            }
+            Instruction::InfiniteLoop { src, body } => {
+                let body = self.lowir(epool, *body);
+                let ins = LowIRIns::InfiniteLoop { src, body };
+                self.add(ins)
+            }
+            Instruction::WhileLoop {
+                src,
+                condition,
+                body,
+            } => {
+                let condition = epool.lowir(condition);
+                let body = self.lowir(epool, *body);
+                let ins = LowIRIns::WhileLoop {
+                    src,
+                    condition,
+                    body,
+                };
+                self.add(ins)
+            }
+            Instruction::CodeBlock { src, instructions } => {
+                let instructions = instructions
+                    .into_iter()
+                    .map(|i| self.lowir(epool, i))
+                    .collect();
+                let ins = LowIRIns::CodeBlock { src, instructions };
+                self.add(ins)
+            }
+            Instruction::Module {
+                name,
+                body,
+                src,
+                is_public,
+            } => {
+                let name = epool.lowir(name);
+                let body = self.lowir(epool, *body);
+                let ins = LowIRIns::Module {
+                    name,
+                    body,
+                    src,
+                    is_public,
+                };
+                self.add(ins)
+            }
+            Instruction::Return { src, value } => {
+                let value = value.map(|v| epool.lowir(v));
+                let ins = LowIRIns::Return { src, value };
+                self.add(ins)
+            }
+            Instruction::Break(src) => {
+                let ins = LowIRIns::Break(src);
+                self.add(ins)
+            }
+            Instruction::Continue(src) => {
+                let ins = LowIRIns::Continue(src);
+                self.add(ins)
+            }
+            Instruction::UseDependency { paths, src } => {
+                let ins = LowIRIns::UseDependency { paths, src };
+                self.add(ins)
+            }
+            Instruction::DirectiveInstruction {
+                directive,
+                block,
+                src,
+            } => {
+                let directive = epool.lowir(directive);
+                let block = block.map(|b| self.lowir(epool, *b));
+                let ins = LowIRIns::DirectiveInstruction {
+                    directive,
+                    block,
+                    src,
+                };
+                self.add(ins)
+            }
+            Instruction::ConditionalBranchIns { pairs, src } => {
+                let pairs = pairs
+                    .into_iter()
+                    .map(|(cond, body)| {
+                        if let Some(cond) = cond {
+                            let cond = epool.lowir(cond);
+                            let body = self.lowir(epool, *body);
+                            (Some(cond), body)
+                        } else {
+                            let body = self.lowir(epool, *body);
+                            (None, body)
+                        }
+                    })
+                    .collect();
+                let ins = LowIRIns::ConditionalBranchIns { pairs, src };
+                self.add(ins)
+            }
+        }
+    }
+
+    pub fn get(&self, ins_ref: &InsRef) -> LowIRIns {
+        self.pool[ins_ref.loc].clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LowIRModule {
+    pub ins_pool: InsPool,
+    pub expr_pool: ExprPool,
+    pub top_level: Vec<InsRef>,
+}
+
+#[allow(dead_code)]
+impl LowIRModule {
+    pub fn new() -> LowIRModule {
+        LowIRModule {
+            ins_pool: InsPool::new(),
+            expr_pool: ExprPool::new(),
+            top_level: Vec::new(),
+        }
+    }
+
+    pub fn lowir(&mut self, cm: CompilationModule) {
+        for ins in cm.instructions {
+            let id = self.ins_pool.lowir(&mut self.expr_pool, ins);
+            self.top_level.push(id);
+        }
+    }
+}

--- a/src/ir8/mod.rs
+++ b/src/ir8/mod.rs
@@ -1,3 +1,4 @@
 pub mod codeviewer;
 pub mod lowir;
+pub mod tomato;
 pub mod visitir;

--- a/src/ir8/mod.rs
+++ b/src/ir8/mod.rs
@@ -1,0 +1,3 @@
+pub mod codeviewer;
+pub mod lowir;
+pub mod visitir;

--- a/src/ir8/tomato.rs
+++ b/src/ir8/tomato.rs
@@ -1,0 +1,36 @@
+use super::codeviewer::CodeViewer;
+#[allow(unused_imports)]
+use super::lowir::{ExprPool, InsPool, InsRef, KeyValueBindings, LowIRModule};
+#[allow(unused_imports)]
+use super::visitir::apply_to_module;
+use std::fs;
+use std::io::Error;
+
+#[allow(dead_code)]
+pub struct Tomato {
+    pub filepath: String,
+    viewer: CodeViewer,
+}
+
+#[allow(dead_code)]
+impl Tomato {
+    pub fn new(filename: String, ins_pool: InsPool, expr_pool: ExprPool) -> Tomato {
+        Tomato {
+            filepath: filename,
+            viewer: CodeViewer::new(ins_pool, expr_pool),
+        }
+    }
+
+    pub fn format(&mut self, ir_module: &LowIRModule) -> Result<(), Error> {
+        let res = apply_to_module(&mut self.viewer, &ir_module);
+        let res = self.viewer.unwrap(res);
+
+        let contents = res.join("\n\n");
+        self.update_file_contents(contents)
+    }
+
+    fn update_file_contents(&self, contents: String) -> Result<(), Error> {
+        // open file
+        fs::write(&self.filepath, contents)
+    }
+}

--- a/src/ir8/visitir.rs
+++ b/src/ir8/visitir.rs
@@ -1,0 +1,30 @@
+use super::lowir::{ExprRef, InsRef, KeyValueBindings, LowIRModule};
+
+#[allow(dead_code)]
+pub enum VisitIRError {}
+
+#[allow(dead_code)]
+pub trait VisitsLowIR<A, B, C> {
+    fn visit_ins(&mut self, ins: &InsRef) -> Result<A, VisitIRError>;
+    fn visit_expr(&mut self, expr: &ExprRef) -> Result<B, VisitIRError>;
+    fn visit_pairs(&mut self, kv: &KeyValueBindings) -> Result<C, VisitIRError>;
+}
+
+pub fn apply_visitor<A, B, C, V: VisitsLowIR<A, B, C>>(
+    visitor: &mut V,
+    ins: &InsRef,
+) -> Result<A, VisitIRError> {
+    visitor.visit_ins(ins)
+}
+
+pub fn apply_to_module<A, B, C, V: VisitsLowIR<A, B, C>>(
+    visitor: &mut V,
+    module: &LowIRModule,
+) -> Vec<Result<A, VisitIRError>> {
+    let mut result = vec![];
+    for ins_ref in module.top_level.iter() {
+        let res = apply_visitor(visitor, &ins_ref);
+        result.push(res);
+    }
+    result
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use frontend::{
     parser::Parser,
     source::{SourceFile, SourceReporter},
 };
-use ir8::{codeviewer::CodeViewer, lowir::LowIRModule, visitir::apply_to_module};
+use ir8::lowir::LowIRModule;
 use serde::Deserialize;
 
 use crate::frontend::token::Token;
@@ -56,7 +56,7 @@ fn main() {
     let path = fs::canonicalize(PathBuf::from(path)).unwrap();
     let path = path.to_str().unwrap().to_string();
 
-    let src = SourceFile::new(path);
+    let src = SourceFile::new(path.clone());
     let reporter = SourceReporter::new(src.clone());
     let mut lexer = Lexer::new(src);
 
@@ -97,9 +97,15 @@ fn main() {
         let module = parser.compilation_module;
         let mut ir_mod = LowIRModule::new();
         ir_mod.lowir(module);
-        let mut show_code = CodeViewer::new(ir_mod.ins_pool.clone(), ir_mod.expr_pool.clone());
-        let res = apply_to_module(&mut show_code, &ir_mod);
-        let res = show_code.unwrap(res);
-        println!("{}", res.join("\n\n"));
+        // let mut tomato = Tomato::new(
+        //     path.clone(),
+        //     ir_mod.ins_pool.clone(),
+        //     ir_mod.expr_pool.clone(),
+        // );
+
+        // match tomato.format(&ir_mod) {
+        //     Ok(()) => reporter.show_info(format!("formatted {}", path)),
+        //     Err(e) => reporter.show_info(format!("failed to format {}: {}", path, e)),
+        // }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,6 @@ fn main() {
         let mut show_code = CodeViewer::new(ir_mod.ins_pool.clone(), ir_mod.expr_pool.clone());
         let res = apply_to_module(&mut show_code, &ir_mod);
         let res = show_code.unwrap(res);
-        println!("{}", res.join("\n"));
+        println!("{}", res.join("\n\n"));
     }
 }


### PR DESCRIPTION
Inspired by this [article](https://www.cs.cornell.edu/~asampson/blog/flattening.html), added lowering step. Will work on parsing comments as part of ast. This will allow me write a proto's formatter, tomato, properly. Only thing currently missing is actually comments. They can occur any where, which makes them interesting to handle and I have not handled comments before.